### PR TITLE
add !important support to float mixin #10

### DIFF
--- a/bi-app/_mixins.scss
+++ b/bi-app/_mixins.scss
@@ -66,19 +66,19 @@
 
 // float
 // ------------------------------------------
-@mixin bi-app-float-left {
-  float: $bi-app-left;
+@mixin bi-app-float-left($important: '') {
+  float: $bi-app-left unquote($important);
 }
 
-@mixin bi-app-float-right {
-  float: $bi-app-right;
+@mixin bi-app-float-right($important: '') {
+  float: $bi-app-right unquote($important);
 }
 
-@mixin float($direction) {
+@mixin float($direction, $important: '') {
   @if $direction == left {
-    @include bi-app-float-left;
+    @include bi-app-float-left($important);
   } @else if $direction == right {
-    @include bi-app-float-right;
+    @include bi-app-float-right($important);
   } @else {
     float: $direction;
   }

--- a/bi-app/_variables-ltr.scss
+++ b/bi-app/_variables-ltr.scss
@@ -1,15 +1,16 @@
 // ------------------------------------------
 // left to right variables to be used by bi-app mixins
-// authors: 
+// authors:
 // twitter.com/anasnakawa
 // twitter.com/victorzamfir
-// licensed under the MIT license 
+// licensed under the MIT license
 // http://www.opensource.org/licenses/mit-license.php
 // ------------------------------------------
 
 // namespacing variables with bi-app to
 // avoid conflicting with other global variables
 $bi-app-left 				    : left;
-$bi-app-right 				  : right;
-$bi-app-direction 			: ltr;
-$bi-app-invert-direction: rtl;
+$bi-app-right 				  	: right;
+$bi-app-direction 				: ltr;
+$bi-app-invert-direction		: rtl;
+$imp                    		: !important;

--- a/bi-app/_variables-rtl.scss
+++ b/bi-app/_variables-rtl.scss
@@ -1,15 +1,16 @@
 // ------------------------------------------
 // right to left variables to be used by bi-app mixins
-// authors: 
+// authors:
 // twitter.com/anasnakawa
 // twitter.com/victorzamfir
-// licensed under the MIT license 
+// licensed under the MIT license
 // http://www.opensource.org/licenses/mit-license.php
 // ------------------------------------------
 
 // namespacing variables with bi-app to
 // avoid conflicting with other global variables
 $bi-app-left 				    : right;
-$bi-app-right           : left;
-$bi-app-direction 			: rtl;
-$bi-app-invert-direction: ltr;
+$bi-app-right           		: left;
+$bi-app-direction 				: rtl;
+$bi-app-invert-direction		: ltr;
+$imp                    		: !important;


### PR DESCRIPTION
Now it supports `!important` by passing `$imp` as a second optional argument to the mixin and it's backward compatible 