### PR TITLE
Fixed typo in github pages index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@ ltr
 <p>whenever you face a special case, the <code>rtl</code> &amp; <code>ltr</code> mixins will give you hand :)</p>
 
 <pre><code>.some-class {
-    @inlcude rtl {
+    @include rtl {
       // what you write here, will appear only in rtl stylesheets
       background-image: url('rtl/some-image.jpg');
       background-position: -10px 30px;


### PR DESCRIPTION
Very awesome project BTW. It helps me and the folks @edX to RTL the biggest open courses platform https://edx.org (https://github.com/edx/edx-platform/pull/2682).

The typo here is very nasty, it puzzled me for a couple of moments.
